### PR TITLE
get async-session working with tide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,19 @@ authors = [
 
 [dependencies]
 async-trait = "0.1.24"
-async-std = "1.5.0"
-cookie = "0.13.3"
-uuid = {version = "0.8.1", features = ["v4"] }
+async-std = "1.6.0"
+serde = { version = "1.0.114", features = ["rc", "derive"] }
+rand = "0.7.3"
+base64 = "0.12.3"
+sha2 = "0.9.1"
+hmac = "0.8.1"
+serde_json = "1.0.56"
+kv-log-macro = "1.0.7"
+bincode = "1.3.1"
+chrono = { version = "0.4.13", features = ["serde"] }
+anyhow = "1.0.31"
+blake3 = "0.3.5"
+
 
 [dev-dependencies]
-tide = "0.6.0"
+async-std = { version = "1.6.2", features = ["attributes"] }

--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -1,0 +1,137 @@
+use crate::{async_trait, Result, Session, SessionStore};
+
+/// A session store that serializes the entire session into a Cookie.
+///
+/// # ***This is not recommended for most production deployments.***
+///
+/// This implementation uses [`bincode`](::bincode) to serialize the
+/// Session to decrease the size of the cookie. Note: There is a
+/// maximum of 4093 cookie bytes allowed _per domain_, so the cookie
+/// store is limited in capacity.
+///
+/// **Note:** Currently, the data in the cookie is only signed, but *not
+/// encrypted*. If the contained session data is sensitive and
+/// should not be read by a user, the cookie store is not an
+/// appropriate choice.
+///
+/// Expiry: `SessionStore::destroy_session` and
+/// `SessionStore::clear_store` are not meaningful for the
+/// CookieStore, and noop. Destroying a session must be done at the
+/// cookie setting level, which is outside of the scope of this crate.
+
+#[derive(Debug, Clone, Copy)]
+pub struct CookieStore;
+
+impl CookieStore {
+    /// constructs a new CookieStore
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl SessionStore for CookieStore {
+    async fn load_session(&self, cookie_value: String) -> Result<Option<Session>> {
+        let serialized = base64::decode(&cookie_value)?;
+        let session: Session = bincode::deserialize(&serialized)?;
+        Ok(session.validate())
+    }
+
+    async fn store_session(&self, session: Session) -> Result<Option<String>> {
+        let serialized = bincode::serialize(&session)?;
+        Ok(Some(base64::encode(serialized)))
+    }
+
+    async fn destroy_session(&self, _session: Session) -> Result {
+        Ok(())
+    }
+
+    async fn clear_store(&self) -> Result {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_std::task;
+    use std::time::Duration;
+    #[async_std::test]
+    async fn creating_a_new_session_with_no_expiry() -> Result {
+        let store = CookieStore::new();
+        let mut session = Session::new();
+        session.insert("key", "Hello")?;
+        let cloned = session.clone();
+        let cookie_value = store.store_session(session).await?.unwrap();
+        let loaded_session = store.load_session(cookie_value).await?.unwrap();
+        assert_eq!(cloned.id(), loaded_session.id());
+        assert_eq!("Hello", &loaded_session.get::<String>("key").unwrap());
+        assert!(!loaded_session.is_expired());
+        assert!(loaded_session.validate().is_some());
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn updating_a_session() -> Result {
+        let store = CookieStore::new();
+        let mut session = Session::new();
+
+        session.insert("key", "value")?;
+        let cookie_value = store.store_session(session).await?.unwrap();
+
+        let mut session = store.load_session(cookie_value.clone()).await?.unwrap();
+        session.insert("key", "other value")?;
+
+        let new_cookie_value = store.store_session(session).await?.unwrap();
+        let session = store.load_session(new_cookie_value).await?.unwrap();
+        assert_eq!(&session.get::<String>("key").unwrap(), "other value");
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn updating_a_session_extending_expiry() -> Result {
+        let store = CookieStore::new();
+        let mut session = Session::new();
+        session.expire_in(Duration::from_secs(1));
+        let original_expires = session.expiry().unwrap().clone();
+        let cookie_value = store.store_session(session).await?.unwrap();
+
+        let mut session = store.load_session(cookie_value.clone()).await?.unwrap();
+
+        assert_eq!(session.expiry().unwrap(), &original_expires);
+        session.expire_in(Duration::from_secs(3));
+        let new_expires = session.expiry().unwrap().clone();
+        let cookie_value = store.store_session(session).await?.unwrap();
+
+        let session = store.load_session(cookie_value.clone()).await?.unwrap();
+        assert_eq!(session.expiry().unwrap(), &new_expires);
+
+        task::sleep(Duration::from_secs(3)).await;
+        assert_eq!(None, store.load_session(cookie_value).await?);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn creating_a_new_session_with_expiry() -> Result {
+        let store = CookieStore::new();
+        let mut session = Session::new();
+        session.expire_in(Duration::from_secs(3));
+        session.insert("key", "value")?;
+        let cloned = session.clone();
+
+        let cookie_value = store.store_session(session).await?.unwrap();
+
+        let loaded_session = store.load_session(cookie_value.clone()).await?.unwrap();
+        assert_eq!(cloned.id(), loaded_session.id());
+        assert_eq!("value", &*loaded_session.get::<String>("key").unwrap());
+
+        assert!(!loaded_session.is_expired());
+
+        task::sleep(Duration::from_secs(3)).await;
+        assert_eq!(None, store.load_session(cookie_value).await?);
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,185 +1,70 @@
 //! Async HTTP sessions.
 //!
-//! This crate provides a generic interface between cookies and storage
-//! backends to create a concept of sessions. It provides an interface that
-//! can be used to encode and store sessions, and decode and load sessions
-//! generating cookies in the process.
+//! This crate provides a generic interface between cookie values and
+//! storage backends to create a concept of sessions. It provides an
+//! interface that can be used to encode and store sessions, and
+//! decode and load sessions generating cookies in the process.
 //!
-//! # Security
-//!
-//! This module has not been vetted for security purposes, and in particular
-//! the in-memory storage backend is wildly insecure. Please thoroughly
-//! validate whether this crate is a match for your intended use case before
-//! relying on it in any sensitive context.
-//!
-//! # Examples
+//! # Example
 //!
 //! ```
-//! use async_session::mem::MemoryStore;
-//! use async_session::{Session, SessionStore};
-//! use cookie::CookieJar;
+//! use async_session::{Session, SessionStore, MemoryStore};
 //!
-//! # fn main() -> std::io::Result<()> {
+//! # fn main() -> async_session::Result {
 //! # async_std::task::block_on(async {
 //! #
 //! // Init a new session store we can persist sessions to.
 //! let mut store = MemoryStore::new();
 //!
 //! // Create a new session.
-//! let sess = store.create_session();
+//! let mut session = Session::new();
+//! session.insert("user_id", 1)?;
+//! assert!(session.data_changed());
 //!
-//! // Persist the session to our backend, and store a cookie
-//! // to later access the session.
-//! let mut jar = CookieJar::new();
-//! let sess = store.store_session(sess, &mut jar).await?;
+//! // retrieve the cookie value to store in a session cookie
+//! let cookie_value = store.store_session(session).await?.unwrap();
 //!
 //! // Retrieve the session using the cookie.
-//! let sess = store.load_session(&jar).await?;
-//! println!("session: {:?}", sess);
+//! let session = store.load_session(cookie_value).await?.unwrap();
+//! assert_eq!(session.get::<usize>("user_id").unwrap(), 1);
+//! assert!(!session.data_changed());
 //! #
 //! # Ok(()) }) }
 //! ```
 
-#![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
-#![deny(missing_debug_implementations, nonstandard_style)]
-#![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
+// #![forbid(unsafe_code, future_incompatible)]
+// #![deny(missing_debug_implementations, nonstandard_style)]
+// #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
+#![forbid(unsafe_code, future_incompatible)]
+#![deny(
+    missing_debug_implementations,
+    nonstandard_style,
+    missing_docs,
+    unreachable_pub,
+    missing_copy_implementations,
+    unused_qualifications
+)]
 
-use async_trait::async_trait;
-use std::collections::HashMap;
+pub use anyhow::Error;
+/// An anyhow::Result with default return type of ()
+pub type Result<T = ()> = std::result::Result<T, Error>;
 
-/// An async session backend.
-#[async_trait]
-pub trait SessionStore: Send + Sync + 'static + Clone {
-    /// The type of error that can occur when storing and loading errors.
-    type Error;
+mod cookie_store;
+mod memory_store;
+mod session;
+mod session_store;
 
-    /// Get a session from the storage backend.
-    ///
-    /// The input should usually be the content of a cookie. This will then be
-    /// parsed by the session middleware into a valid session.
-    async fn load_session(&self, jar: &cookie::CookieJar) -> Result<Session, Self::Error>;
+pub use cookie_store::CookieStore;
+pub use memory_store::MemoryStore;
+pub use session::Session;
+pub use session_store::SessionStore;
 
-    /// Store a session on the storage backend.
-    ///
-    /// This method should return a stringified representation of the session so
-    /// that it can be sent back to the client through a cookie.
-    async fn store_session(
-        &mut self,
-        session: Session,
-        jar: &mut cookie::CookieJar,
-    ) -> Result<(), Self::Error>;
-}
-
-/// The main session type.
-#[derive(Clone, Debug)]
-pub struct Session {
-    inner: HashMap<String, String>,
-}
-
-impl Session {
-    /// Create a new session.
-    pub fn new() -> Self {
-        Self {
-            inner: HashMap::new(),
-        }
-    }
-
-    /// Insert a new value into the Session.
-    pub fn insert(&mut self, k: String, v: String) -> Option<String> {
-        self.inner.insert(k, v)
-    }
-
-    /// Get a value from the session.
-    pub fn get(&self, k: &str) -> Option<&String> {
-        self.inner.get(k)
-    }
-}
-
-/// In-memory session store.
-pub mod mem {
-    use async_std::io::{Error, ErrorKind};
-    use async_std::sync::{Arc, RwLock};
-    use cookie::Cookie;
-    use std::collections::HashMap;
-
-    use async_trait::async_trait;
-    use uuid::Uuid;
-
-    use crate::{Session, SessionStore};
-
-    /// An in-memory session store.
-    ///
-    /// # Security
-    ///
-    /// This store *does not* generate secure sessions, and should under no
-    /// circumstance be used in production. It's meant only to quickly create
-    /// sessions.
-    #[derive(Debug)]
-    pub struct MemoryStore {
-        inner: Arc<RwLock<HashMap<String, Session>>>,
-    }
-
-    impl MemoryStore {
-        /// Create a new instance of MemoryStore.
-        pub fn new() -> Self {
-            Self {
-                inner: Arc::new(RwLock::new(HashMap::new())),
-            }
-        }
-
-        /// Generates a new session by generating a new uuid.
-        ///
-        /// This is *not* a secure way of generating sessions, and is intended for debug purposes only.
-        pub fn create_session(&self) -> Session {
-            let mut sess = Session::new();
-            sess.insert("id".to_string(), uuid::Uuid::new_v4().to_string());
-            sess
-        }
-    }
-
-    impl Clone for MemoryStore {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl SessionStore for MemoryStore {
-        /// The type of error that can occur when storing and loading errors.
-        type Error = std::io::Error;
-
-        /// Get a session from the storage backend.
-        async fn load_session(&self, jar: &cookie::CookieJar) -> Result<Session, Self::Error> {
-            let id = match jar.get("session") {
-                Some(cookie) => Uuid::parse_str(cookie.value()),
-                None => return Err(Error::new(ErrorKind::Other, "No session cookie found")),
-            };
-
-            let id = id
-                .map_err(|_| Error::new(ErrorKind::Other, "Cookie content was not a valid uuid"))?
-                .to_string();
-
-            let inner = self.inner.read().await;
-            let sess = inner.get(&id).ok_or(Error::from(ErrorKind::Other))?;
-            Ok(sess.clone())
-        }
-
-        /// Store a session on the storage backend.
-        ///
-        /// The data inside the session will be url-encoded so it can be stored
-        /// inside a cookie.
-        async fn store_session(
-            &mut self,
-            sess: Session,
-            jar: &mut cookie::CookieJar,
-        ) -> Result<(), Self::Error> {
-            let mut inner = self.inner.write().await;
-            let id = sess.get("id").unwrap().to_string();
-            inner.insert(id.clone(), sess);
-            jar.add(Cookie::new("session", id));
-            Ok(())
-        }
-    }
-}
+pub use async_trait::async_trait;
+pub use base64;
+pub use blake3;
+pub use chrono;
+pub use hmac;
+pub use kv_log_macro as log;
+pub use serde;
+pub use serde_json;
+pub use sha2;

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -1,0 +1,221 @@
+use crate::{async_trait, log, Result, Session, SessionStore};
+use async_std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+
+/// # in-memory session store
+/// Because there is no external
+/// persistance, this session store is ephemeral and will be cleared
+/// on server restart.
+///
+/// # ***DO NOT USE THIS IN A PRODUCTION DEPLOYMENT.***
+#[derive(Debug, Clone)]
+pub struct MemoryStore {
+    inner: Arc<RwLock<HashMap<String, Session>>>,
+}
+
+#[async_trait]
+impl SessionStore for MemoryStore {
+    async fn load_session(&self, cookie_value: String) -> Result<Option<Session>> {
+        let id = Session::id_from_cookie_value(&cookie_value)?;
+        log::trace!("loading session by id `{}`", id);
+        Ok(self
+            .inner
+            .read()
+            .await
+            .get(&id)
+            .cloned()
+            .and_then(Session::validate))
+    }
+
+    async fn store_session(&self, session: Session) -> Result<Option<String>> {
+        log::trace!("storing session by id `{}`", session.id());
+        self.inner
+            .write()
+            .await
+            .insert(session.id().to_string(), session.clone());
+
+        session.reset_data_changed();
+        Ok(session.into_cookie_value())
+    }
+
+    async fn destroy_session(&self, session: Session) -> Result {
+        log::trace!("destroying session by id `{}`", session.id());
+        self.inner.write().await.remove(session.id());
+        Ok(())
+    }
+
+    async fn clear_store(&self) -> Result {
+        log::trace!("clearing memory store");
+        self.inner.write().await.clear();
+        Ok(())
+    }
+}
+
+impl MemoryStore {
+    /// Create a new instance of MemoryStore
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Performs session cleanup. This should be run on an
+    /// intermittent basis if this store is run for long enough that
+    /// memory accumulation is a concern
+    pub async fn cleanup(&self) -> Result {
+        log::trace!("cleaning up memory store...");
+        let ids_to_delete: Vec<_> = self
+            .inner
+            .read()
+            .await
+            .values()
+            .filter_map(|session| {
+                if session.is_expired() {
+                    Some(session.id().to_owned())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        log::trace!("found {} expired sessions", ids_to_delete.len());
+        for id in ids_to_delete {
+            self.inner.write().await.remove(&id);
+        }
+        Ok(())
+    }
+
+    /// returns the number of elements in the memory store
+    /// # Example
+    /// ```rust
+    /// # use async_session::{MemoryStore, Session, SessionStore};
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut store = MemoryStore::new();
+    /// assert_eq!(store.count().await, 0);
+    /// store.store_session(Session::new()).await?;
+    /// assert_eq!(store.count().await, 1);
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn count(&self) -> usize {
+        let data = self.inner.read().await;
+        data.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_std::task;
+    use std::time::Duration;
+    #[async_std::test]
+    async fn creating_a_new_session_with_no_expiry() -> Result {
+        let store = MemoryStore::new();
+        let mut session = Session::new();
+        session.insert("key", "Hello")?;
+        let cloned = session.clone();
+        let cookie_value = store.store_session(session).await?.unwrap();
+        let loaded_session = store.load_session(cookie_value).await?.unwrap();
+        assert_eq!(cloned.id(), loaded_session.id());
+        assert_eq!("Hello", &loaded_session.get::<String>("key").unwrap());
+        assert!(!loaded_session.is_expired());
+        assert!(loaded_session.validate().is_some());
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn updating_a_session() -> Result {
+        let store = MemoryStore::new();
+        let mut session = Session::new();
+
+        session.insert("key", "value")?;
+        let cookie_value = store.store_session(session).await?.unwrap();
+
+        let mut session = store.load_session(cookie_value.clone()).await?.unwrap();
+        session.insert("key", "other value")?;
+
+        assert_eq!(store.store_session(session).await?, None);
+        let session = store.load_session(cookie_value).await?.unwrap();
+        assert_eq!(&session.get::<String>("key").unwrap(), "other value");
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn updating_a_session_extending_expiry() -> Result {
+        let store = MemoryStore::new();
+        let mut session = Session::new();
+        session.expire_in(Duration::from_secs(1));
+        let original_expires = session.expiry().unwrap().clone();
+        let cookie_value = store.store_session(session).await?.unwrap();
+
+        let mut session = store.load_session(cookie_value.clone()).await?.unwrap();
+
+        assert_eq!(session.expiry().unwrap(), &original_expires);
+        session.expire_in(Duration::from_secs(3));
+        let new_expires = session.expiry().unwrap().clone();
+        assert_eq!(None, store.store_session(session).await?);
+
+        let session = store.load_session(cookie_value.clone()).await?.unwrap();
+        assert_eq!(session.expiry().unwrap(), &new_expires);
+
+        task::sleep(Duration::from_secs(3)).await;
+        assert_eq!(None, store.load_session(cookie_value).await?);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn creating_a_new_session_with_expiry() -> Result {
+        let store = MemoryStore::new();
+        let mut session = Session::new();
+        session.expire_in(Duration::from_secs(3));
+        session.insert("key", "value")?;
+        let cloned = session.clone();
+
+        let cookie_value = store.store_session(session).await?.unwrap();
+
+        let loaded_session = store.load_session(cookie_value.clone()).await?.unwrap();
+        assert_eq!(cloned.id(), loaded_session.id());
+        assert_eq!("value", &*loaded_session.get::<String>("key").unwrap());
+
+        assert!(!loaded_session.is_expired());
+
+        task::sleep(Duration::from_secs(3)).await;
+        assert_eq!(None, store.load_session(cookie_value).await?);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn destroying_a_single_session() -> Result {
+        let store = MemoryStore::new();
+        for _ in 0..3i8 {
+            store.store_session(Session::new()).await?;
+        }
+
+        let cookie = store.store_session(Session::new()).await?.unwrap();
+        assert_eq!(4, store.count().await);
+        let session = store.load_session(cookie.clone()).await?.unwrap();
+        store.destroy_session(session.clone()).await?;
+        assert_eq!(None, store.load_session(cookie).await?);
+        assert_eq!(3, store.count().await);
+
+        // attempting to destroy the session again is not an error
+        assert!(store.destroy_session(session).await.is_ok());
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn clearing_the_whole_store() -> Result {
+        let store = MemoryStore::new();
+        for _ in 0..3i8 {
+            store.store_session(Session::new()).await?;
+        }
+
+        assert_eq!(3, store.count().await);
+        store.clear_store().await.unwrap();
+        assert_eq!(0, store.count().await);
+
+        Ok(())
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,536 @@
+use chrono::{DateTime, Duration, Utc};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+};
+
+/// # The main session type.
+///
+/// ## Cloning and Serialization
+///
+/// The `cookie_value` field is not cloned or serialized, and it can
+/// only be read through `into_cookie_value`. The intent of this field
+/// is that it is set either by initialization or by a session store,
+/// and read exactly once in order to set the cookie value.
+///
+/// ## Change tracking session tracks whether any of its inner data
+/// was changed since it was last serialized. Any sessoin store that
+/// does not undergo a serialization-deserialization cycle must call
+/// [`Session::reset_data_changed`] in order to reset the change tracker on
+/// an individual record.
+///
+/// ### Change tracking example
+/// ```rust
+/// # use async_session::Session;
+/// # fn main() -> async_session::Result { async_std::task::block_on(async {
+/// let mut session = Session::new();
+/// assert!(!session.data_changed());
+///
+/// session.insert("key", 1)?;
+/// assert!(session.data_changed());
+///
+/// session.reset_data_changed();
+/// assert_eq!(session.get::<usize>("key").unwrap(), 1);
+/// assert!(!session.data_changed());
+///
+/// session.insert("key", 2)?;
+/// assert!(session.data_changed());
+/// assert_eq!(session.get::<usize>("key").unwrap(), 2);
+///
+/// session.insert("key", 1)?;
+/// assert!(session.data_changed(), "reverting the data still counts as a change");
+///
+/// session.reset_data_changed();
+/// assert!(!session.data_changed());
+/// session.remove("nonexistent key");
+/// assert!(!session.data_changed());
+/// session.remove("key");
+/// assert!(session.data_changed());
+/// # Ok(()) }) }
+/// ```
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Session {
+    #[serde(skip)]
+    cookie_value: Option<String>,
+    id: String,
+    expiry: Option<DateTime<Utc>>,
+    data: Arc<RwLock<HashMap<String, String>>>,
+    #[serde(skip)]
+    data_changed: Arc<AtomicBool>,
+    destroy: Arc<AtomicBool>,
+}
+
+impl Clone for Session {
+    fn clone(&self) -> Self {
+        Self {
+            cookie_value: None,
+            id: self.id.clone(),
+            data: self.data.clone(),
+            expiry: self.expiry,
+            destroy: self.destroy.clone(),
+            data_changed: self.data_changed.clone(),
+        }
+    }
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// generates a random cookie value
+fn generate_cookie(len: usize) -> String {
+    let mut key = vec![0u8; len];
+    rand::thread_rng().fill_bytes(&mut key);
+    base64::encode(key)
+}
+
+impl Session {
+    /// Create a new session. Generates a random id and matching
+    /// cookie value. Does not set an expiry by default
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let session = Session::new();
+    /// assert_eq!(None, session.expiry());
+    /// assert!(session.into_cookie_value().is_some());
+    /// # Ok(()) }) }
+    pub fn new() -> Self {
+        let cookie_value = generate_cookie(64);
+        let id = Session::id_from_cookie_value(&cookie_value).unwrap();
+
+        Self {
+            data_changed: Arc::new(AtomicBool::new(false)),
+            expiry: None,
+            data: Arc::new(RwLock::new(HashMap::default())),
+            cookie_value: Some(cookie_value),
+            id,
+            destroy: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// applies a cryptographic hash function on a cookie value
+    /// returned by [`Session::into_cookie_value`] to obtain the
+    /// session id for that cookie. Returns an error if the cookie
+    /// format is not recognized
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let session = Session::new();
+    /// let id = session.id().to_string();
+    /// let cookie_value = session.into_cookie_value().unwrap();
+    /// assert_eq!(id, Session::id_from_cookie_value(&cookie_value)?);
+    /// # Ok(()) }) }
+    /// ```
+    pub fn id_from_cookie_value(string: &str) -> Result<String, base64::DecodeError> {
+        let decoded = base64::decode(string)?;
+        let hash = blake3::hash(&decoded);
+        Ok(base64::encode(&hash.as_bytes()))
+    }
+
+    /// mark this session for destruction. the actual session record
+    /// is not destroyed until the end of this response cycle.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert!(!session.is_destroyed());
+    /// session.destroy();
+    /// assert!(session.is_destroyed());
+    /// # Ok(()) }) }
+    pub fn destroy(&mut self) {
+        self.destroy.store(true, Ordering::Relaxed);
+    }
+
+    /// returns true if this session is marked for destruction
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert!(!session.is_destroyed());
+    /// session.destroy();
+    /// assert!(session.is_destroyed());
+    /// # Ok(()) }) }
+
+    pub fn is_destroyed(&self) -> bool {
+        self.destroy.load(Ordering::Relaxed)
+    }
+
+    /// Gets the session id
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let session = Session::new();
+    /// let id = session.id().to_owned();
+    /// let cookie_value = session.into_cookie_value().unwrap();
+    /// assert_eq!(id, Session::id_from_cookie_value(&cookie_value)?);
+    /// # Ok(()) }) }
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// inserts a serializable value into the session hashmap. returns
+    /// an error if the serialization was unsuccessful.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use serde::{Serialize, Deserialize};
+    /// # use async_session::Session;
+    /// #[derive(Serialize, Deserialize)]
+    /// struct User {
+    ///     name: String,
+    ///     legs: u8
+    /// }
+    /// let mut session = Session::new();
+    /// session.insert("user", User { name: "chashu".into(), legs: 4 }).expect("serializable");
+    /// assert_eq!(r#"{"name":"chashu","legs":4}"#, session.get_raw("user").unwrap());
+    /// ```
+    pub fn insert(&mut self, key: &str, value: impl Serialize) -> Result<(), serde_json::Error> {
+        self.insert_raw(key, serde_json::to_string(&value)?);
+        Ok(())
+    }
+
+    /// inserts a string into the session hashmap
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// let mut session = Session::new();
+    /// session.insert_raw("ten", "10".to_string());
+    /// let ten: usize = session.get("ten").unwrap();
+    /// assert_eq!(ten, 10);
+    /// ```
+    pub fn insert_raw(&mut self, key: &str, value: String) {
+        let mut data = self.data.write().unwrap();
+        if data.get(key) != Some(&value) {
+            data.insert(key.to_string(), value);
+            self.data_changed.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// deserializes a type T out of the session hashmap
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// let mut session = Session::new();
+    /// session.insert("key", vec![1, 2, 3]);
+    /// let numbers: Vec<usize> = session.get("key").unwrap();
+    /// assert_eq!(vec![1, 2, 3], numbers);
+    /// ```
+    pub fn get<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
+        let data = self.data.read().unwrap();
+        let string = data.get(key)?;
+        serde_json::from_str(string).ok()
+    }
+
+    /// returns the String value contained in the session hashmap
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// let mut session = Session::new();
+    /// session.insert("key", vec![1, 2, 3]);
+    /// assert_eq!("[1,2,3]", session.get_raw("key").unwrap());
+    /// ```
+    pub fn get_raw(&self, key: &str) -> Option<String> {
+        let data = self.data.read().unwrap();
+        data.get(key).cloned()
+    }
+
+    /// removes an entry from the session hashmap
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// let mut session = Session::new();
+    /// session.insert("key", "value");
+    /// session.remove("key");
+    /// assert!(session.get_raw("key").is_none());
+    /// assert_eq!(session.len(), 0);
+    /// ```
+    pub fn remove(&mut self, key: &str) {
+        let mut data = self.data.write().unwrap();
+        if data.remove(key).is_some() {
+            self.data_changed.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// returns the number of elements in the session hashmap
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// let mut session = Session::new();
+    /// assert_eq!(session.len(), 0);
+    /// session.insert("key", 0);
+    /// assert_eq!(session.len(), 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        let data = self.data.read().unwrap();
+        data.len()
+    }
+
+    /// Generates a new id and cookie for this session
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// let old_id = session.id().to_string();
+    /// session.regenerate();
+    /// assert!(session.id() != &old_id);
+    /// let new_id = session.id().to_string();
+    /// let cookie_value = session.into_cookie_value().unwrap();
+    /// assert_eq!(new_id, Session::id_from_cookie_value(&cookie_value)?);
+    /// # Ok(()) }) }
+    /// ```
+    pub fn regenerate(&mut self) {
+        let cookie_value = generate_cookie(64);
+        self.id = Session::id_from_cookie_value(&cookie_value).unwrap();
+        self.cookie_value = Some(cookie_value);
+    }
+
+    /// sets the cookie value that this session will use to serialize
+    /// itself. this should only be called by cookie stores. any other
+    /// uses of this method will result in the cookie not getting
+    /// correctly deserialized on subsequent requests.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// session.set_cookie_value("hello".to_owned());
+    /// let cookie_value = session.into_cookie_value().unwrap();
+    /// assert_eq!(cookie_value, "hello".to_owned());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn set_cookie_value(&mut self, cookie_value: String) {
+        self.cookie_value = Some(cookie_value)
+    }
+
+    /// returns the expiry timestamp of this session, if there is one
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert_eq!(None, session.expiry());
+    /// session.expire_in(std::time::Duration::from_secs(1));
+    /// assert!(session.expiry().is_some());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn expiry(&self) -> Option<&DateTime<Utc>> {
+        self.expiry.as_ref()
+    }
+
+    /// assigns an expiry timestamp to this session
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert_eq!(None, session.expiry());
+    /// session.set_expiry(chrono::Utc::now());
+    /// assert!(session.expiry().is_some());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn set_expiry(&mut self, expiry: DateTime<Utc>) {
+        self.expiry = Some(expiry);
+    }
+
+    /// assigns the expiry timestamp to a duration from the current time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert_eq!(None, session.expiry());
+    /// session.expire_in(std::time::Duration::from_secs(1));
+    /// assert!(session.expiry().is_some());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn expire_in(&mut self, ttl: std::time::Duration) {
+        self.expiry = Some(Utc::now() + Duration::from_std(ttl).unwrap());
+    }
+
+    /// predicate function to determine if this session is
+    /// expired. returns false if there is no expiry set, or if it is
+    /// in the past.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # use std::time::Duration;
+    /// # use async_std::task;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert_eq!(None, session.expiry());
+    /// assert!(!session.is_expired());
+    /// session.expire_in(Duration::from_secs(1));
+    /// assert!(!session.is_expired());
+    /// task::sleep(Duration::from_secs(2)).await;
+    /// assert!(session.is_expired());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn is_expired(&self) -> bool {
+        match self.expiry {
+            Some(expiry) => expiry < Utc::now(),
+            None => false,
+        }
+    }
+
+    /// Ensures that this session is not expired. Returns None if it is expired
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # use std::time::Duration;
+    /// # use async_std::task;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let session = Session::new();
+    /// let mut session = session.validate().unwrap();
+    /// session.expire_in(Duration::from_secs(1));
+    /// let session = session.validate().unwrap();
+    /// task::sleep(Duration::from_secs(2)).await;
+    /// assert_eq!(None, session.validate());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn validate(self) -> Option<Self> {
+        if self.is_expired() {
+            None
+        } else {
+            Some(self)
+        }
+    }
+
+    /// Checks if the data has been modified. This is based on the
+    /// implementation of [`PartialEq`] for the inner data type.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert!(!session.data_changed(), "new session is not changed");
+    /// session.insert("key", 1);
+    /// assert!(session.data_changed());
+    ///
+    /// session.reset_data_changed();
+    /// assert!(!session.data_changed());
+    /// session.remove("key");
+    /// assert!(session.data_changed());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn data_changed(&self) -> bool {
+        self.data_changed.load(Ordering::Relaxed)
+    }
+
+    /// Resets `data_changed` dirty tracking. This is unnecessary for
+    /// any session store that serializes the data to a string on
+    /// storage.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// assert!(!session.data_changed(), "new session is not changed");
+    /// session.insert("key", 1);
+    /// assert!(session.data_changed());
+    ///
+    /// session.reset_data_changed();
+    /// assert!(!session.data_changed());
+    /// session.remove("key");
+    /// assert!(session.data_changed());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn reset_data_changed(&self) {
+        self.data_changed.store(false, Ordering::Relaxed);
+    }
+
+    /// Ensures that this session is not expired. Returns None if it is expired
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # use std::time::Duration;
+    /// # use async_std::task;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// session.expire_in(Duration::from_secs(123));
+    /// let expires_in = session.expires_in().unwrap();
+    /// assert!(123 - expires_in.as_secs() < 2);
+    /// # Ok(()) }) }
+    /// ```
+    /// Duration from now to the expiry time of this session
+    pub fn expires_in(&self) -> Option<std::time::Duration> {
+        self.expiry?.signed_duration_since(Utc::now()).to_std().ok()
+    }
+
+    /// takes the cookie value and consume this session.
+    /// this is generally only performed by the session store
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use async_session::Session;
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// let mut session = Session::new();
+    /// session.set_cookie_value("hello".to_owned());
+    /// let cookie_value = session.into_cookie_value().unwrap();
+    /// assert_eq!(cookie_value, "hello".to_owned());
+    /// # Ok(()) }) }
+    /// ```
+    pub fn into_cookie_value(mut self) -> Option<String> {
+        self.cookie_value.take()
+    }
+}
+
+impl PartialEq for Session {
+    fn eq(&self, other: &Self) -> bool {
+        other.id == self.id
+    }
+}

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -1,0 +1,24 @@
+use crate::{async_trait, Result, Session};
+
+/// An async session backend.
+#[async_trait]
+pub trait SessionStore: std::fmt::Debug + Send + Sync + Clone + 'static {
+    /// Get a session from the storage backend.
+    ///
+    /// The input is expected to be the value of an identifying
+    /// cookie. This will then be parsed by the session middleware
+    /// into a session if possible
+    async fn load_session(&self, cookie_value: String) -> Result<Option<Session>>;
+
+    /// Store a session on the storage backend.
+    ///
+    /// The return value is the value of the cookie to store for the
+    /// user that represents this session
+    async fn store_session(&self, session: Session) -> Result<Option<String>>;
+
+    /// Remove a session from the session store
+    async fn destroy_session(&self, session: Session) -> Result;
+
+    /// Empties the entire store, destroying all sessions
+    async fn clear_store(&self) -> Result;
+}


### PR DESCRIPTION
this pr represents fairly large changes to async-session in order to get it to work with tide.  In particular, the CookieJar was not readily accessible inside of tide, so SessionStores are no longer responsible for setting or getting the cookie. Instead, stores accept an already-fetched cookie value string to load, and return the cookie value as a string on save. This also adds an `Arc<RwLock<…>>` to Session, in order to allow interior mutation. The shared internal state across multiple clones is necessary in order to support tide's approach to Extensions ([ref](https://github.com/http-rs/http-types/pull/201)).

Most session stores except cookie store will need some notion of an id, so Session by default generates a random cookie and an id that is a sha256 digest of that cookie.  SessionStores are encouraged to use this derived id to index the Session and not retain the original cookie. This ensures that if an adversary got ahold of a read-only copy of the session database, they would not be able to generate a session cookie, as *we* are unable to generate those cookies more than once. This protection is expected to be layered on top of signed cookies, which is outside of the purview of this library.