### PR TITLE
we don't need to serialize destroy

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -55,13 +55,15 @@ use std::{
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Session {
-    #[serde(skip)]
-    cookie_value: Option<String>,
     id: String,
     expiry: Option<DateTime<Utc>>,
     data: Arc<RwLock<HashMap<String, String>>>,
+
+    #[serde(skip)]
+    cookie_value: Option<String>,
     #[serde(skip)]
     data_changed: Arc<AtomicBool>,
+    #[serde(skip)]
     destroy: Arc<AtomicBool>,
 }
 


### PR DESCRIPTION
if the record is being serialized, destroy should be false (because destroy is an ephemeral flag on session that tells the host application to remove the session from the store).

this avoids addressing an issue with serde's serialization of atomicbool on arm arch and closes http-rs/tide#673