### PR TITLE
Stronger guarantees for atomics

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -156,7 +156,7 @@ impl Session {
     /// assert!(session.is_destroyed());
     /// # Ok(()) }) }
     pub fn destroy(&mut self) {
-        self.destroy.store(true, Ordering::Relaxed);
+        self.destroy.store(true, Ordering::SeqCst);
     }
 
     /// returns true if this session is marked for destruction
@@ -173,7 +173,7 @@ impl Session {
     /// # Ok(()) }) }
 
     pub fn is_destroyed(&self) -> bool {
-        self.destroy.load(Ordering::Relaxed)
+        self.destroy.load(Ordering::SeqCst)
     }
 
     /// Gets the session id
@@ -229,7 +229,7 @@ impl Session {
         let mut data = self.data.write().unwrap();
         if data.get(key) != Some(&value) {
             data.insert(key.to_string(), value);
-            self.data_changed.store(true, Ordering::Relaxed);
+            self.data_changed.store(true, Ordering::Release);
         }
     }
 
@@ -280,7 +280,7 @@ impl Session {
     pub fn remove(&mut self, key: &str) {
         let mut data = self.data.write().unwrap();
         if data.remove(key).is_some() {
-            self.data_changed.store(true, Ordering::Relaxed);
+            self.data_changed.store(true, Ordering::Release);
         }
     }
 
@@ -465,7 +465,7 @@ impl Session {
     /// # Ok(()) }) }
     /// ```
     pub fn data_changed(&self) -> bool {
-        self.data_changed.load(Ordering::Relaxed)
+        self.data_changed.load(Ordering::Acquire)
     }
 
     /// Resets `data_changed` dirty tracking. This is unnecessary for
@@ -489,7 +489,7 @@ impl Session {
     /// # Ok(()) }) }
     /// ```
     pub fn reset_data_changed(&self) {
-        self.data_changed.store(false, Ordering::Relaxed);
+        self.data_changed.store(false, Ordering::SeqCst);
     }
 
     /// Ensures that this session is not expired. Returns None if it is expired


### PR DESCRIPTION
I'm fairly sure that what we're doing with `Relaxed` ordering isn't correct; not 100% sure that what I'm doing here is accurate, but it should at the very least race less. Thanks!