### PR TITLE
Disable the "oldtime" feature of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hmac = "0.8.1"
 serde_json = "1.0.56"
 kv-log-macro = "1.0.7"
 bincode = "1.3.1"
-chrono = { version = "0.4.13", features = ["serde"] }
+chrono = { version = "0.4.13", default-features = false, features = ["clock", "serde", "std"] }
 anyhow = "1.0.31"
 blake3 = "0.3.5"
 


### PR DESCRIPTION
This removes time 0.1 from the dependencies of crates using
async-session.