### PR TITLE
clone cookie_value on clone

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -70,7 +70,7 @@ pub struct Session {
 impl Clone for Session {
     fn clone(&self) -> Self {
         Self {
-            cookie_value: None,
+            cookie_value: self.cookie_value.clone(),
             id: self.id.clone(),
             data: self.data.clone(),
             expiry: self.expiry,


### PR DESCRIPTION
Hi @yoshuawuyts / @No9,
                                                This change is part of the fix in https://github.com/http-rs/tide/pull/769, we need to clone the `cookie_value` on clone.

Thanks!