### PR TITLE
Don't make SessionStore implement Debug

### DIFF
--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -2,7 +2,7 @@ use crate::{async_trait, Result, Session};
 
 /// An async session backend.
 #[async_trait]
-pub trait SessionStore: std::fmt::Debug + Send + Sync + Clone + 'static {
+pub trait SessionStore: Send + Sync + Clone + 'static {
     /// Get a session from the storage backend.
     ///
     /// The input is expected to be the value of an identifying


### PR DESCRIPTION
Removes the necessity for `SessionStore` to implement `Debug` since not all providers are able to implement it. Namely, the [`ConnectionManager`](https://docs.rs/redis/0.19.0/redis/aio/struct.ConnectionManager.html) from the Redis crate (and I'm sure there are other connection providers that don't implement debug).