### PR TITLE
Upgrade base64, hmac, and rand to current versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ authors = [
 async-trait = "0.1.24"
 async-std = "1.6.0"
 serde = { version = "1.0.114", features = ["rc", "derive"] }
-rand = "0.7.3"
-base64 = "0.12.3"
+rand = "0.8.3"
+base64 = "0.13.0"
 sha2 = "0.9.1"
-hmac = "0.8.1"
+hmac = "0.10.1"
 serde_json = "1.0.56"
 kv-log-macro = "1.0.7"
 bincode = "1.3.1"


### PR DESCRIPTION
This reduces duplicate crate versions in dependency trees that include
async-session.