### PR TITLE
drop dependency on async-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,26 +10,32 @@ edition = "2018"
 keywords = []
 categories = []
 authors = [
-    "Yoshua Wuyts <yoshuawuyts@gmail.com>"
+  "Yoshua Wuyts <yoshuawuyts@gmail.com>",
+  "Jacob Rothstein <hi@jbr.me>"
 ]
 
-[features]
-
 [dependencies]
-async-trait = "0.1.24"
-async-std = "1.6.0"
-serde = { version = "1.0.114", features = ["rc", "derive"] }
+async-trait = "0.1.50"
 rand = "0.8.3"
 base64 = "0.13.0"
-sha2 = "0.9.1"
-hmac = "0.10.1"
-serde_json = "1.0.56"
-kv-log-macro = "1.0.7"
-bincode = "1.3.1"
-chrono = { version = "0.4.13", default-features = false, features = ["clock", "serde", "std"] }
-anyhow = "1.0.31"
-blake3 = "0.3.5"
+sha2 = "0.9.5"
+hmac = "0.11.0"
+serde_json = "1.0.64"
+bincode = "1.3.3"
+anyhow = "1.0.40"
+blake3 = "0.3.8"
+async-lock = "2.4.0"
+log = "0.4.14"
 
+[dependencies.serde]
+version = "1.0.126"
+features = ["rc", "derive"]
 
-[dev-dependencies]
-async-std = { version = "1.6.2", features = ["attributes"] }
+[dependencies.chrono]
+version = "0.4.19"
+default-features = false
+features = ["clock", "serde", "std"]
+
+[dev-dependencies.async-std]
+version = "1.9.0"
+features = ["attributes"]

--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@
   </h3>
 </div>
 
-## Installation
-```sh
-$ cargo add async-session
-```
-
-## Available implementations
+## Available session stores
 
 * [async-sqlx-session](https://crates.io/crates/async-sqlx-session) postgres & sqlite
 * [async-redis-session](https://crates.io/crates/async-redis-session)
 * [async-mongodb-session](https://crates.io/crates/async-mongodb-session)
+
+## Framework implementations
+
+* [tide::sessions](https://docs.rs/tide/latest/tide/sessions/index.html)
+* [warp-sessions](https://docs.rs/warp-sessions/latest/warp_sessions/)
 
 ## Safety
 This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ## Framework implementations
 
-* [tide::sessions](https://docs.rs/tide/latest/tide/sessions/index.html)
+* [`tide::sessions`](https://docs.rs/tide/latest/tide/sessions/index.html)
 * [warp-sessions](https://docs.rs/warp-sessions/latest/warp_sessions/)
 
 ## Safety

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@
 $ cargo add async-session
 ```
 
+## Available implementations
+
+* [async-sqlx-session](https://crates.io/crates/async-sqlx-session) postgres & sqlite
+* [async-redis-session](https://crates.io/crates/async-redis-session)
+* [async-mongodb-session](https://crates.io/crates/async-mongodb-session)
+
 ## Safety
 This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in
 100% Safe Rust.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 // #![forbid(unsafe_code, future_incompatible)]
 // #![deny(missing_debug_implementations, nonstandard_style)]
 // #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
-#![forbid(unsafe_code, future_incompatible)]
+#![forbid(unsafe_code)]
 #![deny(
     missing_debug_implementations,
     nonstandard_style,
@@ -64,7 +64,7 @@ pub use base64;
 pub use blake3;
 pub use chrono;
 pub use hmac;
-pub use kv_log_macro as log;
+pub use log;
 pub use serde;
 pub use serde_json;
 pub use sha2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 // #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
 #![forbid(unsafe_code)]
 #![deny(
+    future_incompatible,
     missing_debug_implementations,
     nonstandard_style,
     missing_docs,

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -1,6 +1,6 @@
 use crate::{async_trait, log, Result, Session, SessionStore};
-use async_std::sync::{Arc, RwLock};
-use std::collections::HashMap;
+use async_lock::RwLock;
+use std::{collections::HashMap, sync::Arc};
 
 /// # in-memory session store
 /// Because there is no external


### PR DESCRIPTION
Async-session is now a framework-independent interface, and should not depend on any specific runtime. Users of [warp-sessions](https://crates.io/crates/warp-sessions) or other frameworks (trillium-sessions, soon) should not have to compile all of async-std just to get an async rwlock.

When this interface was written, it was primarily intended to support tide with a secondary goal of being framework independent. Now that it's already used by two (and soon three) frameworks, the crate should attempt to meet all of their needs as best as possible.

This PR also adds my name to the authors, updates all dependencies, and documents the available stores in the readme, since the [tide documentation points there](https://docs.rs/tide/0.16.0/tide/sessions/index.html#stores)

If approved, I intend to release this, and believe it to be a patch change. There's a small breaking change that impacts none of the public dependent crates: Previously the `log` reexport was actually kv-log-macros, and now it's just the `log` crate.