### PR TITLE
update the blake3 dependency to v1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ hmac = "0.11.0"
 serde_json = "1.0.64"
 bincode = "1.3.3"
 anyhow = "1.0.40"
-blake3 = "0.3.8"
+blake3 = "1.2.0"
 async-lock = "2.4.0"
 log = "0.4.14"
 


### PR DESCRIPTION
The blake3 crate currently has a MSRV of 1.51 for const generics.