### PR TITLE
drop supertrait requirements on SessionStore

### DIFF
--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -2,7 +2,7 @@ use crate::{async_trait, Result, Session};
 
 /// An async session backend.
 #[async_trait]
-pub trait SessionStore: std::fmt::Debug + Send + Sync + Clone + 'static {
+pub trait SessionStore {
     /// Get a session from the storage backend.
     ///
     /// The input is expected to be the value of an identifying


### PR DESCRIPTION
with this change, frameworks can specify if they need any or all of these constraints, like `SessionStore + Send + Sync + 'static`

closes #33 